### PR TITLE
add instructor and schedule to course info

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 
 # render_template -  api uses to generate html 
 # request - object we need for forms 
+from data.modify_data import clean_course_info
 from flask import Flask, jsonify, request, redirect, render_template, flash
 import pandas as pd 
 import pickle
@@ -15,6 +16,9 @@ for file_name in ['data/encrypted_all_courses.csv', 'data/encrypted_courses.csv'
 
 with open("data/decrypted_vectors_all_attributes.pkl", "rb") as handle:
     vector_courses = pickle.load(handle)
+    
+# modify course data (note: could be done before encryption)
+clean_course_info(vector_courses)
 
 @app.route('/')
 def index():

--- a/data/modify_data.py
+++ b/data/modify_data.py
@@ -1,0 +1,31 @@
+import ast
+
+def clean_course_info(df):
+    format_instructors(df)
+    create_schedule(df)
+
+def format_instructors(df):
+	def join_faculty(row):
+		faculty = ast.literal_eval(row['Faculty'])
+		return "; ".join(faculty)
+	df["Faculty"] = df.apply(join_faculty, axis=1)
+  
+def create_schedule(df):
+	def join_weekdays_meetimes(row):
+		weekdays = ast.literal_eval(row['Weekdays'])
+		meettimes = ast.literal_eval(row['MeetTime'])
+		# Check if the lengths of both lists are the same
+		if len(weekdays) == len(meettimes):
+			combined_data = []
+			for i in range(len(weekdays)):
+				combined_string = weekdays[i] + " " + meettimes[i]
+				combined_data.append(combined_string)
+			return "\n".join(combined_data)
+		# Often To be arranged
+		elif len(meettimes) == 1 and weekdays[0] == []:
+			return meettimes[0]
+		else:
+			return "Format Error: " + row['Weekdays'] + row['MeetTime']
+
+	df["Schedule"] = df.apply(join_weekdays_meetimes, axis=1)
+    

--- a/templates/result.html
+++ b/templates/result.html
@@ -58,6 +58,16 @@
                     <p>{{ table['Description'] }}</p>
                     <hr style="margin: 16px 0">
                     <p class="uppercase-title">
+                        Instructor(s)
+                    </p>
+                    <p>{{ table['Faculty'] }}</p>
+                    <hr style="margin: 16px 0">
+                    <p class="uppercase-title">
+                        Schedule
+                    </p>
+                    <p style="white-space: pre-line">{{ table['Schedule']}}</p>
+                    <hr style="margin: 16px 0">
+                    <p class="uppercase-title">
                         Prerequisites
                     </p>
                     <p>{% if table['Prereqs'] %}{{ table['Prereqs'] }}{% else %}None{% endif %}</p>


### PR DESCRIPTION
### Description

Show the instructor(s) and schedule for courses. To do so: modified data after loading from the pickle file, adding or reformating certain columns.

### Test
tested locally 
case | screenshot
-- | -- 
Schedule TBA | ![Screenshot 2023-10-31 at 1 21 09 PM](https://github.com/aspc/p-recs/assets/69527053/a58d5390-3f96-4b5a-9685-38b209bdf3b0)
Multiple instructors | ![Screenshot 2023-10-31 at 1 31 51 PM](https://github.com/aspc/p-recs/assets/69527053/d68e04a2-04fd-401e-ae08-589d8196dff0)
Multiple schedules | ![Screenshot 2023-10-31 at 1 23 35 PM](https://github.com/aspc/p-recs/assets/69527053/e7687a3c-f9c8-4951-97c8-37707c05647f)

