### PR TITLE
Updated css to fix footer overflow problem

### DIFF
--- a/static/stylesheets/style.css
+++ b/static/stylesheets/style.css
@@ -37,6 +37,7 @@ h1 {
 	text-align: left;
 	padding: 16px;
 	box-sizing: border-box;
+    overflow-y: auto;
 }
 
 .checkboxes input[type="checkbox"] {


### PR DESCRIPTION
Description: 
* Before: Our footer overflow with the text on favourite column whenever resizing the window:

  <img width="500" alt="Screenshot 2023-11-17 at 4 31 09 PM" src="https://github.com/aspc/p-recs/assets/79251745/58d473bb-69c9-4b24-b336-73d69a162c47">
  <img width="500" alt="Screenshot 2023-11-17 at 4 31 16 PM" src="https://github.com/aspc/p-recs/assets/79251745/5d3c8ea4-9447-4994-ad5a-b8d3b0364050">

* After fixing css:
  <img width="500" alt="Screenshot 2023-11-17 at 4 30 16 PM" src="https://github.com/aspc/p-recs/assets/79251745/d71b9a77-ed8b-4be5-a31b-393adf052490">
  <img width="500" alt="Screenshot 2023-11-17 at 4 30 09 PM" src="https://github.com/aspc/p-recs/assets/79251745/1e287317-bfef-4c73-ab1e-3395dfd3fe55">
